### PR TITLE
Minimum length increased to avoid reading uninitialised data.

### DIFF
--- a/VescUartControl.cpp
+++ b/VescUartControl.cpp
@@ -123,7 +123,7 @@ bool VescController::UartGetValue(bldcMeasure& values)
 	int lenPayload = ReceiveUartMessage(payload);
 
 	if (lenPayload > 55) {
-		bool read = ProcessReadPacket(payload, values, lenPayload); //returns true if sucessfull
+		bool read = ProcessReadPacket(payload, values, lenPayload); //returns true if sucessful
 		return read;
 	}
 	else
@@ -141,7 +141,7 @@ bool VescController::UartGetLimits(bldcLimits& limits)
 	delay(100); //needed, otherwise data is not read it is needed in addition to _Serial.flush()
 	int lenPayload = ReceiveUartMessage(payload);
 
-	if (lenPayload > 0)
+	if (lenPayload > 0) //TODO add the default lenght of the Payload here also
 	{
 		bool read = ProcessReadPacketLimits(payload, limits, lenPayload); //returns true if sucessful
 		return read;

--- a/VescUartControl.cpp
+++ b/VescUartControl.cpp
@@ -122,7 +122,7 @@ bool VescController::UartGetValue(bldcMeasure& values)
 	delay(100); //needed, otherwise data is not read it is needed in addition to _Serial.flush()
 	int lenPayload = ReceiveUartMessage(payload);
 
-	if (lenPayload > 0) {
+	if (lenPayload > 55) {
 		bool read = ProcessReadPacket(payload, values, lenPayload); //returns true if sucessfull
 		return read;
 	}

--- a/VescUartControl.cpp
+++ b/VescUartControl.cpp
@@ -141,7 +141,7 @@ bool VescController::UartGetLimits(bldcLimits& limits)
 	delay(100); //needed, otherwise data is not read it is needed in addition to _Serial.flush()
 	int lenPayload = ReceiveUartMessage(payload);
 
-	if (lenPayload > 0) //TODO add the default lenght of the Payload here also
+	if (lenPayload > 56)
 	{
 		bool read = ProcessReadPacketLimits(payload, limits, lenPayload); //returns true if sucessful
 		return read;


### PR DESCRIPTION
Problems encountered when the getValues packet was reflected back down the serial port and was read as a valid value results packet. The easy solution is to ensure that the values packet is at least 55 bytes long as this is the length of all the data it should contain.
Submitted by https://github.com/pinski1 to the original VescUartControl